### PR TITLE
SIF-49 ショートカットモデルの型を変更

### DIFF
--- a/lib/setting.dart
+++ b/lib/setting.dart
@@ -10,61 +10,65 @@ class Setting extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Center(
-            child: Column(
-      children: [
-        SwitchListTile(
-          title: Text('通知'),
-          value: _toggled,
-          secondary: Icon(Icons.airplanemode_active),
-          onChanged: (bool value) {},
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-        ListTile(
-          leading: Icon(Icons.monetization_on),
-          title: Text("予算入力"),
-          onTap: () {},
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-        ListTile(
-          leading: Icon(Icons.folder_open),
-          title: Text("カテゴリ一覧"),
-          onTap: () {},
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-        SwitchListTile(
-          title: Text("起動時に入力画面に推移"),
-          value: _toggled,
-          onChanged: (bool value) {},
-          secondary: const Icon(Icons.fast_forward),
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-        SwitchListTile(
-          title: Text("ショートカット即時登録"),
-          value: _toggled,
-          onChanged: (bool value) {},
-          secondary: const Icon(Icons.fast_forward),
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-        ListTile(
-          leading: Icon(Icons.edit),
-          title: Text("ショートカット編集"),
-          onTap: () {},
-        ),
-        Divider(
-          thickness: 1.2,
-        ),
-      ],
-    )));
+      body: Center(
+        child: Column(
+          children: [
+            SwitchListTile(
+              title: Text('通知'),
+              value: _toggled,
+              secondary: Icon(Icons.airplanemode_active),
+              onChanged: (bool value) {},
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+            ListTile(
+              leading: Icon(Icons.monetization_on),
+              title: Text("予算入力"),
+              onTap: () {},
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+            ListTile(
+              leading: Icon(Icons.folder_open),
+              title: Text("カテゴリ一覧"),
+              onTap: () {},
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+            SwitchListTile(
+              title: Text("起動時に入力画面に推移"),
+              value: _toggled,
+              onChanged: (bool value) {},
+              secondary: const Icon(Icons.fast_forward),
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+            SwitchListTile(
+              title: Text("ショートカット即時登録"),
+              value: _toggled,
+              onChanged: (bool value) {},
+              secondary: const Icon(Icons.fast_forward),
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+            ListTile(
+              leading: Icon(Icons.edit),
+              title: Text("ショートカット編集"),
+              onTap: () {
+                Navigator.of(context).pushNamed('/shortcut');
+              },
+            ),
+            Divider(
+              thickness: 1.2,
+            ),
+          ],
+        )
+      )
+    );
   }
 }

--- a/lib/shortcut.dart
+++ b/lib/shortcut.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
+
 import 'package:saifu/shortcut_model.dart';
 
+import 'package:intl/intl.dart';
+
 class ShortcutPage extends StatelessWidget {
-  final List<ShortcutModel> _shortcutList = [
-    ShortcutModel(price: '￥1000', icon: Icons.add, name: '住田'),
-    ShortcutModel(price: '￥2000', icon: Icons.face, name: '田中'),
+  final formatter = NumberFormat("#,###");
+
+  final List<ShortcutItemModel> _shortcutList = [
+    ShortcutItemModel(price: 1000, icon: Icons.face, name: '住田'),
+    ShortcutItemModel(price: 500, icon: Icons.money, name: '石ころ'),
+    ShortcutItemModel(price: 35100, icon: Icons.radio, name: 'なんか電化'),
   ];
 
   Widget _shortcutItem({int index}) {
@@ -25,7 +31,7 @@ class ShortcutPage extends StatelessWidget {
           ),
           Expanded(
             flex: 4,
-            child: Text(_shortcutList[index].price),
+            child: Text('￥' + formatter.format(_shortcutList[index].price)),
           ),
         ],
       ),

--- a/lib/shortcut_model.dart
+++ b/lib/shortcut_model.dart
@@ -11,15 +11,3 @@ class ShortcutItemModel {
     @required this.price,
   });
 }
-                    
-class ShortcutModel {
-  IconData icon;
-  String name;
-  String price;
-
-  ShortcutModel({
-    this.icon,
-    this.name,
-    @required this.price,
-  });
-}


### PR DESCRIPTION
## 概要

shortcut_modelが2つあったので統合し、型を合わせた
設定画面からショートカット編集画面に遷移できるようにした

## 確認用サイト

https://teamsaifu.github.io/Saifu_Flutter/

